### PR TITLE
Toggle dithering effect

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ See the section about [deployment](https://facebook.github.io/create-react-app/d
 
 - Animated star field driven by an audio analyser
 - Post–processing stack using `postprocessing` for god rays and SMAA anti–aliasing
+- Dithering shader based on Codrops tutorial (press "D" to toggle)
 - Optional device orientation controls for mobile users
 
 ## Learn More

--- a/src/components/three.tsx
+++ b/src/components/three.tsx
@@ -38,7 +38,8 @@ import {
   loadText,
   createFontMesh,
   createFontLine,
-  setupStars
+  setupStars,
+  DitheringEffect
 } from "../threejs";
 
 import { colorPalette, fftSize } from "../threejs/config";
@@ -57,6 +58,7 @@ const circle = setupCircle();
 scene.add(circle);
 
 const smaaEffect = new SMAAEffect({ preset: SMAAPreset.MEDIUM });
+const ditheringEffect = new DitheringEffect();
 
 const stars = setupStars();
 scene.add(stars);
@@ -139,6 +141,7 @@ const ThreeScene = () => {
   const [isAudioLoaded, setAudioLoadingStatus] = useState(false);
   const [isMuted, setMuteStatus] = useState(false);
   const [isOrientControl, setChecked] = useState(false);
+  const [isDithering, setDithering] = useState(false);
 
   const debounceSetFontForm = useCallback(debounce(setFontForm, 10), []);
 
@@ -265,6 +268,24 @@ const ThreeScene = () => {
     [isMobile, isOrientControl]
   );
 
+  useEffect(() => {
+    const handler = (event: KeyboardEvent) => {
+      if (event.key.toLowerCase() === "d") {
+        setDithering((v) => !v);
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, []);
+
+  useEffect(() => {
+    if (isDithering) {
+      effectPass.addEffect(ditheringEffect);
+    } else {
+      effectPass.removeEffect(ditheringEffect);
+    }
+  }, [isDithering]);
+
   return (
     <>
       {!isAudioLoaded ? (
@@ -315,7 +336,7 @@ const ThreeScene = () => {
                   ? "Move your device around (or Touch/Pinch) "
                   : "Touch/Pinch your screen "
                 : "Darg/Zoom your mouse "}
-              to explore
+              to explore. Press "D" to toggle dithering.
             </small>
           </div>
         </div>

--- a/src/threejs/DitheringEffect.ts
+++ b/src/threejs/DitheringEffect.ts
@@ -1,0 +1,49 @@
+import { Effect, BlendFunction } from "postprocessing";
+import { Uniform } from "three";
+
+const fragmentShader = `
+uniform float amount;
+
+float bayer(vec2 pos) {
+    int x = int(mod(pos.x, 4.0));
+    int y = int(mod(pos.y, 4.0));
+    int index = x + y * 4;
+    float limit[16] = float[16](
+        0.0, 8.0, 2.0, 10.0,
+        12.0, 4.0, 14.0, 6.0,
+        3.0, 11.0, 1.0, 9.0,
+        15.0, 7.0, 13.0, 5.0
+    );
+    return (limit[index] + 0.5) / 16.0;
+}
+
+void mainImage(const in vec4 inputColor, const in vec2 uv, out vec4 outputColor) {
+    float threshold = bayer(gl_FragCoord.xy);
+    outputColor = vec4(floor(inputColor.rgb * amount + threshold) / amount, inputColor.a);
+}
+`;
+
+export interface DitheringEffectOptions {
+  blendFunction?: BlendFunction;
+  amount?: number;
+}
+
+export class DitheringEffect extends Effect {
+  constructor({ blendFunction = BlendFunction.NORMAL, amount = 4 }: DitheringEffectOptions = {}) {
+    super("DitheringEffect", fragmentShader, {
+      blendFunction,
+      uniforms: new Map([["amount", new Uniform(amount)]])
+    });
+  }
+
+  get amount(): number {
+    return this.uniforms.get("amount")!.value as number;
+  }
+
+  set amount(value: number) {
+    const uniform = this.uniforms.get("amount");
+    if (uniform) {
+      uniform.value = value;
+    }
+  }
+}

--- a/src/threejs/index.ts
+++ b/src/threejs/index.ts
@@ -125,3 +125,5 @@ export const setupStars = (starCount = 1000) => {
   });
   return new Points(starGeo, starMaterial);
 };
+
+export { DitheringEffect } from "./DitheringEffect";


### PR DESCRIPTION
## Summary
- make dithering effect optional via keyboard toggle
- document the new shortcut in README

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*
- `npm run typecheck` *(fails: missing type declarations)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_b_6842f366e0548324aa65df89029e9a05